### PR TITLE
fix compatibility with magento 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "mageplaza/module-core": "*"
   },
   "type": "magento2-module",
-  "version": "1.4.1",
   "license": "Mageplaza License",
   "keywords": [
       "magento 2",

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -9,8 +9,5 @@
                 <block class="Magento\Directory\Block\Currency" name="opengraph.currency" as="meta.currency"
                        template="Magento_Catalog::product/view/opengraph/currency.phtml"/>
         </referenceBlock>
-
-        <referenceContainer name="after.body.start" before="-">
-        </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -13,9 +13,6 @@
             </block>
         </referenceBlock>
 
-        <referenceContainer name="after.body.start" before="-">
-        </referenceContainer>
-
         <referenceContainer name="page.top">
             <block class="Mageplaza\Seo\Block\Widget\Breadcrumbs" name="mageplaza_seo_breadcrumbs"
                    after="-"


### PR DESCRIPTION
before attribute is not allowed on referenceContainer, and these were
empty anyway, so they could be removed.