### PR TITLE
strip style and script tags from product-description

### DIFF
--- a/Plugin/SeoRender.php
+++ b/Plugin/SeoRender.php
@@ -426,11 +426,16 @@ class SeoRender
                     ->getFrontend()->getValue($product);
                 $modelName       = $this->helperData->getRichsnippetsConfig('model_name');
 
+                $description = preg_replace([
+                    '/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/',
+                    '/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/',
+                ], '', $currentProduct->getDescription());
+
                 $productStructuredData = [
                     '@context'    => 'http://schema.org/',
                     '@type'       => 'Product',
                     'name'        => $currentProduct->getName(),
-                    'description' => trim(strip_tags($currentProduct->getDescription())),
+                    'description' => trim(strip_tags($description)),
                     'sku'         => $currentProduct->getSku(),
                     'url'         => $currentProduct->getProductUrl(),
                     'image'       => $this->getUrl('pub/media/catalog') . 'product' . $currentProduct->getImage(),


### PR DESCRIPTION
change the output of the product description, so that no script and style-tags will be outputted anymore. 

Before this change the content of the style and script tags has been set to the description of the structured data of the product. 

This will happen when the administrator has used the page builder.

_Future idea: maybe it would be better to make possible to configure which attribute should be used for the description. In case of using the pagebuilder it would be better to use the short_description or an other (custom) attribute._

