### PR TITLE
Fix object type for 'brand' field

### DIFF
--- a/Plugin/SeoRender.php
+++ b/Plugin/SeoRender.php
@@ -484,7 +484,7 @@ class SeoRender
                         ->getAttribute($this->helperData->getRichsnippetsConfig('brand'))
                         ->getFrontend()->getValue($product);
 
-                    $productStructuredData['brand']['@type'] = 'Thing';
+                    $productStructuredData['brand']['@type'] = 'Brand';
                     $productStructuredData['brand']['name']  = $brandValue ?: 'Brand';
                 }
 


### PR DESCRIPTION
This PR fixes the "Invalid object type for field 'brand'"-error in Google Search Console.

The Rich Snippes 'brand' field has a type of 'Thing', but according to the [documentation](https://developers.google.com/search/docs/advanced/structured-data/product#product), it's supposed to be 'Brand'.
