### PR TITLE
Replaced Laravel function `array_first` with vanilla php function `current`

### DIFF
--- a/Plugin/SeoRender.php
+++ b/Plugin/SeoRender.php
@@ -458,7 +458,7 @@ class SeoRender
                         ];
                         if ($review->getRatingVotes()->getData()) {
                             $ratingVotes                = $review->getRatingVotes()->getData();
-                            $vote                       = array_first($ratingVotes);
+                            $vote                       = current($ratingVotes);
                             $reviewData['reviewRating'] = [
                                 '@type'       => 'Rating',
                                 'ratingValue' => $vote['percent'],


### PR DESCRIPTION
<!---
    Thank you for contributing to Mageplaza extension.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
If Laravel is not installed, the function `array_first` does not exist and will cause Magento application to throw an exception. Replaced this function with vanilla php function `current`.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. Fixes https://github.com/mageplaza/magento-2-seo/issues/125
